### PR TITLE
ROS Time shift and C++14 Fix

### DIFF
--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -40,6 +40,9 @@ class DisparityConverter {
 
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/DisparityConverter.hpp
@@ -22,6 +22,14 @@ class DisparityConverter {
     DisparityConverter(
         const std::string frameName, float focalLength, float baseline = 7.5, float minDepth = 80, float maxDepth = 1100, bool getBaseDeviceTimestamp = false);
 
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::ImgFrame> inData, std::deque<DisparityMsgs::DisparityImage>& outImageMsg);
     DisparityImagePtr toRosMsgPtr(std::shared_ptr<dai::ImgFrame> inData);
 

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -29,6 +29,15 @@ class ImageConverter {
     // ImageConverter() = default;
     ImageConverter(const std::string frameName, bool interleaved, bool getBaseDeviceTimestamp = false);
     ImageConverter(bool interleaved, bool getBaseDeviceTimestamp = false);
+    
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData,
                                std::deque<ImageMsgs::Image>& outImageMsgs,
                                dai::RawImgFrame::Type type,

--- a/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImageConverter.hpp
@@ -73,6 +73,9 @@ class ImageConverter {
 
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 }  // namespace ros

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -38,6 +38,9 @@ class ImgDetectionConverter {
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImgDetectionConverter.hpp
@@ -19,6 +19,14 @@ class ImgDetectionConverter {
     // DetectionConverter() = default;
     ImgDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
 
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::ImgDetections> inNetData, std::deque<VisionMsgs::Detection2DArray>& opDetectionMsgs);
 
     Detection2DArrayPtr toRosMsgPtr(std::shared_ptr<dai::ImgDetections> inNetData);

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -32,6 +32,15 @@ class ImuConverter {
                  double magnetic_field_cov = 0.0,
                  bool enable_rotation = false);
     ~ImuConverter();
+    
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::IMUData> inData, std::deque<ImuMsgs::Imu>& outImuMsgs);
     void toRosDaiMsg(std::shared_ptr<dai::IMUData> inData, std::deque<depthai_ros_msgs::ImuWithMagneticField>& outImuMsgs);
 

--- a/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/ImuConverter.hpp
@@ -119,6 +119,9 @@ class ImuConverter {
     ImuSyncMethod _syncMode;
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 
     void fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg);
     void fillImuMsg(dai::IMUReportGyroscope report, ImuMsgs::Imu& msg);

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -19,6 +19,14 @@ class SpatialDetectionConverter {
     // DetectionConverter() = default;
     SpatialDetectionConverter(std::string frameName, int width, int height, bool normalized = false, bool getBaseDeviceTimestamp = false);
 
+    /**
+     * @brief Handles cases in which the ROS time shifts forward or backward
+     *  Should be called at regular intervals or on-change of ROS time, depending
+     *  on monitoring.
+     * 
+     */
+    void updateRosBaseTime();
+
     void toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsg);
 
     void toRosVisionMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData, std::deque<vision_msgs::Detection3DArray>& opDetectionMsg);

--- a/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
+++ b/depthai_bridge/include/depthai_bridge/SpatialDetectionConverter.hpp
@@ -40,6 +40,9 @@ class SpatialDetectionConverter {
     std::chrono::time_point<std::chrono::steady_clock> _steadyBaseTime;
     ::ros::Time _rosBaseTime;
     bool _getBaseDeviceTimestamp;
+    // For handling ROS time shifts and debugging
+    int64_t _totalNsChange{ 0 };
+    static const int64_t ZERO_TIME_DELTA_NS { 100 };
 };
 
 /** TODO(sachin): Do we need to have ros msg -> dai bounding box ?

--- a/depthai_bridge/src/DisparityConverter.cpp
+++ b/depthai_bridge/src/DisparityConverter.cpp
@@ -30,11 +30,13 @@ void DisparityConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -45,11 +45,13 @@ void ImageConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImageConverter.cpp
+++ b/depthai_bridge/src/ImageConverter.cpp
@@ -34,6 +34,26 @@ ImageConverter::ImageConverter(const std::string frameName, bool interleaved, bo
     _rosBaseTime = ::ros::Time::now();
 }
 
+void ImageConverter::updateRosBaseTime()
+{
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
+    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    if(::abs(diff) > 10)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns." );
+    }
+
+}
+
 void ImageConverter::toRosMsgFromBitStream(std::shared_ptr<dai::ImgFrame> inData,
                                            std::deque<ImageMsgs::Image>& outImageMsgs,
                                            dai::RawImgFrame::Type type,

--- a/depthai_bridge/src/ImgDetectionConverter.cpp
+++ b/depthai_bridge/src/ImgDetectionConverter.cpp
@@ -27,11 +27,13 @@ void ImgDetectionConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -39,11 +39,13 @@ void ImuConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_bridge/src/ImuConverter.cpp
+++ b/depthai_bridge/src/ImuConverter.cpp
@@ -28,6 +28,26 @@ ImuConverter::ImuConverter(const std::string& frameName,
 
 ImuConverter::~ImuConverter() = default;
 
+void ImuConverter::updateRosBaseTime()
+{
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
+    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    if(::abs(diff) > 10)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns." );
+    }
+
+}
+
 void ImuConverter::fillImuMsg(dai::IMUReportAccelerometer report, ImuMsgs::Imu& msg) {
     msg.linear_acceleration.x = report.x;
     msg.linear_acceleration.y = report.y;

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -15,6 +15,26 @@ SpatialDetectionConverter::SpatialDetectionConverter(std::string frameName, int 
     _rosBaseTime = ::ros::Time::now();
 }
 
+void SpatialDetectionConverter::updateRosBaseTime()
+{
+    ::ros::Time currentRosTime = ::ros::Time::now();
+    std::chrono::time_point<std::chrono::steady_clock> currentSteadyTime =
+        std::chrono::steady_clock::now();
+    // In nanoseconds
+    auto expectedOffset = std::chrono::duration_cast<std::chrono::nanoseconds>(currentSteadyTime - _steadyBaseTime).count();
+    uint64_t previousBaseTimeNs = _rosBaseTime.toNSec();
+    _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
+    uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
+    int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
+    if(::abs(diff) > 10)
+    {
+        // Has been updated
+        DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
+            std::to_string(diff) << " ns." );
+    }
+
+}
+
 void SpatialDetectionConverter::toRosMsg(std::shared_ptr<dai::SpatialImgDetections> inNetData,
                                          std::deque<SpatialMessages::SpatialDetectionArray>& opDetectionMsgs) {
     // setting the header

--- a/depthai_bridge/src/SpatialDetectionConverter.cpp
+++ b/depthai_bridge/src/SpatialDetectionConverter.cpp
@@ -26,11 +26,13 @@ void SpatialDetectionConverter::updateRosBaseTime()
     _rosBaseTime = _rosBaseTime.fromNSec(currentRosTime.toNSec() - expectedOffset);
     uint64_t newBaseTimeNs = _rosBaseTime.toNSec();
     int64_t diff = static_cast<int64_t>(newBaseTimeNs - previousBaseTimeNs);
-    if(::abs(diff) > 10)
+    _totalNsChange += diff;
+    if(::abs(diff) > ZERO_TIME_DELTA_NS)
     {
         // Has been updated
         DEPTHAI_ROS_DEBUG_STREAM("ROS BASE TIME CHANGE: ", "ROS base time changed by " <<
-            std::to_string(diff) << " ns." );
+            std::to_string(diff) << " ns. Total change: " << std::to_string(_totalNsChange) << " ns. New time: " <<
+            std::to_string(_rosBaseTime.toNSec()) << " ns.");
     }
 
 }

--- a/depthai_filters/CMakeLists.txt
+++ b/depthai_filters/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 add_compile_options(-g)
-add_definitions(-std=c++11)
+add_definitions(-std=c++14)
 
 ## is used, also find other catkin packages
 if(POLICY CMP0057)


### PR DESCRIPTION
## Overview
* Ticket: https://app.shortcut.com/greenzie/story/29249/depthai-time-offset-in-ros-conversion-classes
* Developer(s): @IntelligentJackal 

## Impact
 * Currently, the depthai-ros bridge uses a steady clock, which gets out of sync with ROS clock when the ROS clock shifts, resulting in incorrectly placed detections.
 * This PR adds the ability to shift the steady clock base when the ROS clock shifts, along with debug output.
 * Also found that on some systems (my developer machine), std::make_unique was not found due to a c++11 flag. This PR fixes this issue for building

## Description
n/a

## Changes
* Adds the ability to update the steady clock base with a call similar to when the conversion classes are created.
* Fixes a c++11 flag so this can build on all developer machines
* Makes these changes for all conversion classes.
* Adds debug output for when the steady clock base changes

## Testing
Tested on developer machine - the time updates as expected.

`[ INFO] [1686730398.222581106]: ROS base time changed by -125 ns. Total change: -486 ns. New time: 1686730175933004734 ns.

[ INFO] [1686730401.707956049]: ROS base time changed by -142 ns. Total change: -547 ns. New time: 1686730175933004673 ns.

[ INFO] [1686730401.790594688]: ROS base time changed by 107 ns. Total change: -440 ns. New time: 1686730175933004780 ns.

[ INFO] [1686730403.340893456]: ROS base time changed by -119 ns. Total change: -557 ns. New time: 1686730175933004663 ns.

[ INFO] [1686730403.432030260]: ROS base time changed by 110 ns. Total change: -447 ns. New time: 1686730175933004773 ns.

[ INFO] [1686730404.099595468]: ROS base time changed by -131 ns. Total change: -558 ns. New time: 1686730175933004662 ns.

[ INFO] [1686730404.147011349]: ROS base time changed by 112 ns. Total change: -446 ns. New time: 1686730175933004774 ns.

[ INFO] [1686730404.302058712]: ROS base time changed by -102 ns. Total change: -462 ns. New time: 1686730175933004758 ns.

[ INFO] [1686730409.466964424]: ROS base time changed by 102 ns. Total change: -404 ns. New time: 1686730175933004816 ns.

[ INFO] [1686730411.232166261]: ROS base time changed by -205 ns. Total change: -631 ns. New time: 1686730175933004589 ns.

[ INFO] [1686730411.340365553]: ROS base time changed by 192 ns. Total change: -439 ns. New time: 1686730175933004781 ns.

[ INFO] [1686730420.422422560]: ROS base time changed by -175 ns. Total change: -578 ns. New time: 1686730175933004642 ns.

[ INFO] [1686730420.503819024]: ROS base time changed by 161 ns. Total change: -417 ns. New time: 1686730175933004803 ns.

[ INFO] [1686730449.007171736]: ROS base time changed by -105 ns. Total change: -529 ns. New time: 1686730175933004691 ns.

[ INFO] [1686730449.211304195]: ROS base time changed by 111 ns. Total change: -449 ns. New time: 1686730175933004771 ns.

[ INFO] [1686730449.580690522]: ROS base time changed by 102 ns. Total change: -384 ns. New time: 1686730175933004836 ns.

[ INFO] [1686730450.523697683]: ROS base time changed by -136 ns. Total change: -583 ns. New time: 1686730175933004637 ns.

[ INFO] [1686730450.607717861]: ROS base time changed by 133 ns. Total change: -450 ns. New time: 1686730175933004770 ns.
`
On the developer machine, the offset always stabilized to around 450ns from the original value, without any major ROS time shifts.

## Checklist:
- [x] Tested PR in `developer machine`
